### PR TITLE
Fix issue #3 with simple adaptation of T500RS for use with T150

### DIFF
--- a/tmdrv_devices/thrustmaster_t150.py
+++ b/tmdrv_devices/thrustmaster_t150.py
@@ -1,9 +1,8 @@
 name = 'Thrustmaster T150'
 idVendor = 0x044f
-idProduct = [0xb65d, 0xb677, 0xb677]
+idProduct = [0xb65d, 0xb65e]
 control = [
-	{'step':1, 'request_type':0x41, 'request':83, 'value':0x0006, 'index':0x0000, 'data':b''},
-	{'step':2, 'request_type':0x41, 'request':72, 'value':0x0040, 'index':0x0000, 'data':b''},
+	{'step':1, 'request_type':0x41, 'request':83, 'value':0x0002, 'index':0x0000, 'data':b''},
 ]
 jscal = '6,1,0,16439,16439,32879,32879,1,0,511,511,1054724,1052655,1,0,512,512,1052655,1052655,1,0,510,510,1052655,1050595,1,0,0,0,536854528,536854528,1,0,0,0,536854528,536854528'
-dev_by_id = 'usb-Thrustmaster_TRS_Racing_wheel-joystick'
+dev_by_id = 'usb-Thrustmaster_TRS_Racing_Wheel-joystick'


### PR DESCRIPTION
Pull request regarding my comment on issue https://github.com/her001/tmdrv/issues/3#issuecomment-365505662 :

> After trying without success the t150 branch, I RTFM... And Thrustmaster itself says : 
> 
>  * On PC, the USB sliding switch on the racing wheel's base must always be set to the PS3 position
>  * with the USB sliding switch in the PS3 position, the wheel is recognised in most games as a T500RS
> 
> So I tried tmdrv with the T500RS device :
> ```
> sudo ./tmdrv.py -d thrustmaster_t500rs
> ```
> and got this error :
> ```
> Device "/dev/input/by-id/usb-Thrustmaster_TRS_Racing_wheel-joystick" not found, skipping device calibration
> Traceback (most recent call last):
>   File "./tmdrv.py", line 134, in <module>
>     initialize(args.device)
>   File "./tmdrv.py", line 93, in initialize
>     raise FileNotFoundError
> FileNotFoundError
> ```
> 
> But if I `ls /dev/input/by-id/*` I can see that there is a capital W for **W**heel :
> ```
> usb-Thrustmaster_TRS_Racing_Wheel-event-joystick 
> usb-Thrustmaster_TRS_Racing_Wheel-joystick
> ```
> 
> So I modified `tmdrv_devices/thrustmaster_t500rs.py` to reflect that, ran it again and... it works! Now my two pedals are recognized as proper axises ! No need to change or add data packets as you did in the t150 branch. It simply works !